### PR TITLE
Make a note about .policy.yml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple skeleton application to get you started on React/TypeScript development
 
 ## Getting started
 
+1. Copy or make a fork of this repository (you can delete `.policy.yml`)
 1. Create an application via the Foundry Developer Console, and add `https://localhost:8080/auth/callback` as a redirect URL when asked for one. Once the application has been created, come back to these instructions.
     1. If you know where your application is getting deployed, you can add your production URL as well: `https://example.com/auth/callback`
 1. Set up a `.env` file in the root of this project with the following contents (replace everything in `<>`):


### PR DESCRIPTION
Excavator added a `.policy.yml` to manage approval permissions, but it's not necessary as part of the starter application itself when this repo gets cloned/forked. Making a note in the README for now to mention deleting it. It's otherwise a no-op if policy bot is not used.