### PR TITLE
Mention generating the NPM package in the README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple skeleton application to get you started on React/TypeScript development
     b. If you don't have a production URL yet, you can leave `PRODUCTION_REDIRECT_URL` out. It is only read when you set `NODE_ENV=production`
 
 1. Run `npm install`
-1. Follow the instructions in the Foundry Developer Console to install your application's Ontology SDK via the application-specific NPM registry
+1. Follow the instructions in the Foundry Developer Console to generate and then install your application's Ontology SDK via the application-specific NPM registry
 1. Update the following files with your Ontology SDK and Object types:
     1. Update [`src/utils/client.ts`](./src/utils/client.ts) with the correct package name
     1. Update [`src/pages/home.tsx`](./src/pages/home.tsx) with the correct package name and Ontology Objects you want to use.


### PR DESCRIPTION
We tell folks to install the SDK, but didn't explicitly state they should generate it via the UI first