### PR TITLE
Add .env.sample file

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,4 +1,4 @@
 FOUNDRY_API_URL=https://localhost:8080
 APPLICATION_REDIRECT_URL=https://localhost:8080/auth/callback
 FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
-FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
+API_PROXY_TARGET_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com, for development purposes>

--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,0 +1,4 @@
+FOUNDRY_API_URL=https://localhost:8080
+APPLICATION_REDIRECT_URL=https://localhost:8080/auth/callback
+FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
+FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,0 +1,4 @@
+FOUNDRY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
+APPLICATION_REDIRECT_URL=<Your deployed application domain>/auth/callback
+FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
+FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,3 +1,3 @@
 FOUNDRY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
-APPLICATION_REDIRECT_URL=<Your deployed application domain>/auth/callback
+APPLICATION_REDIRECT_URL=<Fill in the domain at which you deploy your application>/auth/callback
 FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,4 +1,3 @@
 FOUNDRY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
 APPLICATION_REDIRECT_URL=<Your deployed application domain>/auth/callback
 FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
-FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+FOUNDRY_LOCALHOST_API_URL=https://localhost:8080
+LOCALHOST_REDIRECT_URL=https://localhost:8080/auth/callback
+FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
+FOUNDRY_PRODUCTION_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
+PRODUCTION_REDIRECT_URL=<Add your the URL where you are deploying your app, e.g. https://example.app.com>/auth/callback

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
-FOUNDRY_LOCALHOST_API_URL=https://localhost:8080
+LOCALHOST_API_URL=https://localhost:8080
 LOCALHOST_REDIRECT_URL=https://localhost:8080/auth/callback
 FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
-FOUNDRY_PRODUCTION_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
+FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
 PRODUCTION_REDIRECT_URL=<Add your the URL where you are deploying your app, e.g. https://example.app.com>/auth/callback

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,0 @@
-LOCALHOST_API_URL=https://localhost:8080
-LOCALHOST_REDIRECT_URL=https://localhost:8080/auth/callback
-FOUNDRY_CLIENT_ID=<Fill in Client ID for your application>
-FOUNDRY_ONTOLOGY_API_URL=<Fill in your Foundry instance base URL, e.g. https://example.palantir.com>
-PRODUCTION_REDIRECT_URL=<Add your the URL where you are deploying your app, e.g. https://example.app.com>/auth/callback

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-.env
+.env*
 
 # NPM
 node_modules

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A simple skeleton application to get you started on React/TypeScript development
 
 ## Deploying to production
 
-1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_ONTOLOGY_API_URL`, and `APPLICATION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
+1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_API_URL`, and `APPLICATION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
     1. [CircleCi](https://circleci.com/docs/env-vars/#private-keys-and-secrets)
     1. [GitHub Actions](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 1. Before building your application, write an `.env` file to disk:
@@ -37,8 +37,8 @@ A simple skeleton application to get you started on React/TypeScript development
     ```
     # Replace variables with your CI/CD environment variable injection mechanism
     echo FOUNDRY_CLIENT_ID="$FOUNDRY_CLIENT_ID" >> .env.production
-    echo FOUNDRY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env.production
-    echo APPLICATION_REDIRECT_URL="$PRODUCTION_REDIRECT_URL" >> .env.production
+    echo FOUNDRY_API_URL="$FOUNDRY_API_URL" >> .env.production
+    echo APPLICATION_REDIRECT_URL="$APPLICATION_REDIRECT_URL" >> .env.production
     ```
 
 1. Run `npm run build`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ A simple skeleton application to get you started on React/TypeScript development
     ```
     # Replace variables with your CI/CD environment variable injection mechanism
     echo FOUNDRY_CLIENT_ID="$FOUNDRY_CLIENT_ID" >> .env.production
-    echo FOUNDRY_ONTOLOGY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env.production
     echo FOUNDRY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env.production
     echo APPLICATION_REDIRECT_URL="$PRODUCTION_REDIRECT_URL" >> .env.production
     ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A simple skeleton application to get you started on React/TypeScript development
 
 ## Deploying to production
 
-1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_PRODUCTION_API_URL`, and `PRODUCTION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
+1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_ONTOLOGY_API_URL`, and `PRODUCTION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
     1. [CircleCi](https://circleci.com/docs/env-vars/#private-keys-and-secrets)
     1. [GitHub Actions](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 1. Before building your application, write an `.env` file to disk:
@@ -38,7 +38,7 @@ A simple skeleton application to get you started on React/TypeScript development
     ```
     # Replace variables with your CI/CD environment variable injection mechanism
     echo FOUNDRY_CLIENT_ID="$FOUNDRY_CLIENT_ID" >> .env
-    echo FOUNDRY_PRODUCTION_API_URL="$FOUNDRY_PRODUCTION_API_URL" >> .env
+    echo FOUNDRY_ONTOLOGY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env
     echo PRODUCTION_REDIRECT_URL="$PRODUCTION_REDIRECT_URL" >> .env
     ```
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ A simple skeleton application to get you started on React/TypeScript development
     1. Add `https://localhost:8080/auth/callback` as a redirect URL when asked for one
     1. If you know where your application is getting deployed, you can add your production URL as well: `https://example.app.com/auth/callback`
 1. Follow the instructions in the Foundry Developer Console to generate and then install your application's Ontology SDK via the application-specific NPM registry
-1. Run `mv .env.sample .env` to start setting up your environment variables, and fill in the fields marked with `<>`
+1. Run `mv .env.development.sample .env.development` to start setting up your environment variables, and fill in the fields marked with `<>`
 
     a. You can find your Client ID in either the Quickstart guide for the SDK or in the Permissions & OAuth page
-    b. If you don't have a production URL yet, you can leave `PRODUCTION_REDIRECT_URL` out. It is only read when you set `NODE_ENV=production` (i.e. when you run `npm run build`)
 
 1. Update the following files with your Ontology SDK and Object types:
     1. Update [`src/utils/client.ts`](./src/utils/client.ts) with the correct package name
@@ -30,16 +29,17 @@ A simple skeleton application to get you started on React/TypeScript development
 
 ## Deploying to production
 
-1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_ONTOLOGY_API_URL`, and `PRODUCTION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
+1. Store `FOUNDRY_CLIENT_ID`, `FOUNDRY_ONTOLOGY_API_URL`, and `APPLICATION_REDIRECT_URL` in your CI/CD environment secret management system (see below for example documentation)
     1. [CircleCi](https://circleci.com/docs/env-vars/#private-keys-and-secrets)
     1. [GitHub Actions](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
 1. Before building your application, write an `.env` file to disk:
 
     ```
     # Replace variables with your CI/CD environment variable injection mechanism
-    echo FOUNDRY_CLIENT_ID="$FOUNDRY_CLIENT_ID" >> .env
-    echo FOUNDRY_ONTOLOGY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env
-    echo PRODUCTION_REDIRECT_URL="$PRODUCTION_REDIRECT_URL" >> .env
+    echo FOUNDRY_CLIENT_ID="$FOUNDRY_CLIENT_ID" >> .env.production
+    echo FOUNDRY_ONTOLOGY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env.production
+    echo FOUNDRY_API_URL="$FOUNDRY_ONTOLOGY_API_URL" >> .env.production
+    echo APPLICATION_REDIRECT_URL="$PRODUCTION_REDIRECT_URL" >> .env.production
     ```
 
 1. Run `npm run build`

--- a/README.md
+++ b/README.md
@@ -16,18 +16,10 @@ A simple skeleton application to get you started on React/TypeScript development
     1. Add `https://localhost:8080/auth/callback` as a redirect URL when asked for one
     1. If you know where your application is getting deployed, you can add your production URL as well: `https://example.app.com/auth/callback`
 1. Follow the instructions in the Foundry Developer Console to generate and then install your application's Ontology SDK via the application-specific NPM registry
-1. Set up a `.env` file in the root of this project with the following contents (replace everything in `<>`):
-
-    ```
-    FOUNDRY_CLIENT_ID=<Client ID for your application>
-    FOUNDRY_LOCALHOST_API_URL=https://localhost:8080
-    FOUNDRY_PRODUCTION_API_URL=<Your Foundry instance base URL, e.g. https://example.palantir.com>
-    LOCALHOST_REDIRECT_URL=https://localhost:8080/auth/callback
-    PRODUCTION_REDIRECT_URL=<Your production URL, e.g. https://example.app.com>/auth/callback
-    ```
+1. Run `mv .env.sample .env` to start setting up your environment variables, and fill in the fields marked with `<>`
 
     a. You can find your Client ID in either the Quickstart guide for the SDK or in the Permissions & OAuth page
-    b. If you don't have a production URL yet, you can leave `PRODUCTION_REDIRECT_URL` out. It is only read when you set `NODE_ENV=production`
+    b. If you don't have a production URL yet, you can leave `PRODUCTION_REDIRECT_URL` out. It is only read when you set `NODE_ENV=production` (i.e. when you run `npm run build`)
 
 1. Update the following files with your Ontology SDK and Object types:
     1. Update [`src/utils/client.ts`](./src/utils/client.ts) with the correct package name

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -6,10 +6,7 @@ import { FoundryBrowserClient } from "@replace-me/sdk";
  */
 export const client = new FoundryBrowserClient({
     clientId: process.env.FOUNDRY_CLIENT_ID!,
-    url:
-        process.env.NODE_ENV === "production"
-            ? process.env.FOUNDRY_PRODUCTION_API_URL!
-            : process.env.FOUNDRY_LOCALHOST_API_URL!,
+    url: process.env.NODE_ENV === "production" ? process.env.FOUNDRY_ONTOLOGY_API_URL! : process.env.LOCALHOST_API_URL!,
     redirectUrl:
         process.env.NODE_ENV === "production"
             ? process.env.PRODUCTION_REDIRECT_URL!

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -6,9 +6,6 @@ import { FoundryBrowserClient } from "@replace-me/sdk";
  */
 export const client = new FoundryBrowserClient({
     clientId: process.env.FOUNDRY_CLIENT_ID!,
-    url: process.env.NODE_ENV === "production" ? process.env.FOUNDRY_ONTOLOGY_API_URL! : process.env.LOCALHOST_API_URL!,
-    redirectUrl:
-        process.env.NODE_ENV === "production"
-            ? process.env.PRODUCTION_REDIRECT_URL!
-            : process.env.LOCALHOST_REDIRECT_URL!,
+    url: process.env.FOUNDRY_API_URL!,
+    redirectUrl: process.env.APPLICATION_REDIRECT_URL!,
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ module.exports = {
         proxy: [
             {
                 // This proxies calls from the browser to the configured Foundry instance
-                target: process.env.FOUNDRY_ONTOLOGY_API_URL,
+                target: process.env.API_PROXY_TARGET_URL,
                 context: ["/multipass/api/**", "/api/**"],
                 changeOrigin: true,
                 secure: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = {
                 target: process.env.FOUNDRY_ONTOLOGY_API_URL,
                 context: ["/multipass/api/**", "/api/**"],
                 changeOrigin: true,
-                secure: false,
+                secure: true,
             },
         ],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const Dotenv = require("dotenv-webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-require("dotenv").config();
+require("dotenv").config({ path: process.env.NODE_ENV === "production" ? ".env.production" : ".env.development" });
 
 module.exports = {
     entry: {
@@ -90,6 +90,7 @@ module.exports = {
         server: "https",
         proxy: [
             {
+                // This proxies calls from the browser to the configured Foundry instance
                 target: process.env.FOUNDRY_ONTOLOGY_API_URL,
                 context: ["/multipass/api/**", "/api/**"],
                 changeOrigin: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const dotEnvConfig = {
 };
 require("dotenv").config(dotEnvConfig);
 
-console.log(process.env);
 module.exports = {
     entry: {
         app: ["./src/app.tsx", "./src/app.scss"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,12 @@ const path = require("path");
 const Dotenv = require("dotenv-webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-require("dotenv").config({ path: process.env.NODE_ENV === "production" ? ".env.production" : ".env.development" });
+const dotEnvConfig = {
+    path: process.env.NODE_ENV === "production" ? "./.env.production" : "./.env.development",
+};
+require("dotenv").config(dotEnvConfig);
 
+console.log(process.env);
 module.exports = {
     entry: {
         app: ["./src/app.tsx", "./src/app.scss"],
@@ -31,7 +35,7 @@ module.exports = {
             title: "API Example – React",
             template: path.resolve(__dirname, "src/index.html"),
         }),
-        new Dotenv(),
+        new Dotenv(dotEnvConfig),
     ],
     module: {
         rules: [
@@ -94,7 +98,7 @@ module.exports = {
                 target: process.env.FOUNDRY_ONTOLOGY_API_URL,
                 context: ["/multipass/api/**", "/api/**"],
                 changeOrigin: true,
-                secure: true,
+                secure: false,
             },
         ],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = {
         server: "https",
         proxy: [
             {
-                target: process.env.FOUNDRY_PRODUCTION_API_URL,
+                target: process.env.FOUNDRY_ONTOLOGY_API_URL,
                 context: ["/multipass/api/**", "/api/**"],
                 changeOrigin: true,
                 secure: true,


### PR DESCRIPTION
Moves the block from the README to a sample `.env` file that people can just rename directly