### PR TITLE
Switch auth mode for develop

### DIFF
--- a/src/pages/authCallback.tsx
+++ b/src/pages/authCallback.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { client } from "../utils/client";
+import { PublicClientAuth } from "@ontology-starter/sdk";
 
 /**
  * Component to render at `/auth/callback`
@@ -11,7 +12,7 @@ export const AuthCallback: React.FC = () => {
     const navigate = useNavigate();
 
     useEffect(() => {
-        client.auth
+        (client.auth as PublicClientAuth)
             .signIn()
             .then(() => navigate("/"))
             .catch((error: any) => setError(error.message ?? error));

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -3,11 +3,23 @@ import { Navigate } from "react-router-dom";
 
 import "./login.scss";
 import { client } from "../utils/client";
+import { PublicClientAuth } from "@ontology-starter/sdk";
 
 export const LoginPage: React.FC = () => {
+    if (!(client.auth instanceof PublicClientAuth)) {
+        return <></>;
+    }
+    return <LoginPageContent auth={client.auth} />;
+};
+
+interface LoginPageContentProps {
+    auth: PublicClientAuth;
+}
+export const LoginPageContent: React.FC<LoginPageContentProps> = ({ auth }) => {
     const [isLoggingIn, setIsLoggingIn] = useState(false);
     const [error, setError] = useState<string | undefined>(undefined);
-    const token = client.auth.token;
+
+    const token = auth.token;
 
     const onLoginClick = useCallback(async () => {
         setIsLoggingIn(true);
@@ -15,11 +27,11 @@ export const LoginPage: React.FC = () => {
             // Initiate the OAuth flow, which will redirect the user to log into Foundry
             // Once the login has completed, the user will be redirected back to the route defined via the
             // APPLICATION_REDIRECT_URL variable in .env.development
-            await client.auth.signIn();
+            await auth.signIn();
         } catch (err: any) {
             setError(err.message ?? err);
         }
-    }, []);
+    }, [auth]);
 
     // If the token exists but a user tries to load /login, redirect to the home page instead
     if (token != null) {

--- a/src/utils/authenticatedRoute.tsx
+++ b/src/utils/authenticatedRoute.tsx
@@ -1,27 +1,42 @@
 import React, { useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import { client } from "./client";
+import { PublicClientAuth } from "@ontology-starter/sdk";
 
 /**
  * A component that can be used to wrap routes that require authentication.
  * Nested routes may assume that a valid token is present.
  */
 export const AuthenticatedRoute: React.FC = () => {
+    if (client.auth instanceof PublicClientAuth) {
+        return <AuthenticatedRouteContent auth={client.auth} />;
+    }
+    if (process.env.USER_TOKEN == null) {
+        return <div>You are using UserTokenAuth without a token</div>;
+    }
+
+    return <Outlet />;
+};
+
+interface AuthenticatedRouteContentProps {
+    auth: PublicClientAuth;
+}
+export const AuthenticatedRouteContent: React.FC<AuthenticatedRouteContentProps> = ({ auth }) => {
     const navigate = useNavigate();
-    const [token, setToken] = useState(client.auth.token);
+
+    const [token, setToken] = useState(auth.token);
     useEffect(() => {
-        if (client.auth.token == null || client.auth.token.isExpired) {
-            client.auth
-                .refresh()
+        if (auth.token == null || auth.token.isExpired) {
+            auth.signIn()
                 .then(() => {
-                    setToken(client.auth.token);
+                    setToken(auth.token);
                 })
                 .catch(() => {
                     // If we cannot refresh the token (i.e. the user is not logged in) we redirect to the login page
                     navigate("/login");
                 });
         }
-    }, [navigate]);
+    }, [auth, navigate]);
 
     if (token == null || token.isExpired) {
         return null;

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,14 +1,22 @@
 // Replace the package name with your application's package name instead.
-import { FoundryClient, PublicClientAuth } from "@ontology-starter/sdk";
+import { FoundryClient, PublicClientAuth, UserTokenAuth } from "@ontology-starter/sdk";
 
 /**
  * Initialize the client to interact with the Ontology SDK
  */
-export const client = new FoundryClient({
-    url: process.env.FOUNDRY_API_URL!,
-    auth: new PublicClientAuth({
-        clientId: process.env.FOUNDRY_CLIENT_ID!,
-        url: process.env.FOUNDRY_API_URL!,
-        redirectUrl: process.env.APPLICATION_REDIRECT_URL!,
-    }),
-});
+export let client: FoundryClient =
+    process.env.NODE_ENV === "production"
+        ? new FoundryClient({
+              url: process.env.FOUNDRY_API_URL!,
+              auth: new PublicClientAuth({
+                  clientId: process.env.FOUNDRY_CLIENT_ID!,
+                  url: process.env.FOUNDRY_API_URL!,
+                  redirectUrl: process.env.APPLICATION_REDIRECT_URL!,
+              }),
+          })
+        : new FoundryClient({
+              url: process.env.FOUNDRY_API_URL!,
+              auth: new UserTokenAuth({
+                  userToken: process.env.USER_TOKEN!,
+              }),
+          });


### PR DESCRIPTION
To support the new developer role developers will need to use their own token with `UserTokenAuth` until org admin approve the installation of the app. 
This PR shows how the sample code would change to allow switching between both auth modes. 