### PR TITLE
Bump moduleResolution to nodenext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "postcss": "^8.4.23",
                 "postcss-loader": "^7.3.0",
                 "prettier": "^2.8.8",
-                "sass": "^1.69.5",
+                "sass": "~1.69.5",
                 "sass-loader": "^13.2.2",
                 "source-map-loader": "^4.0.1",
                 "style-loader": "^3.3.2",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -28,7 +28,7 @@
             "dom"
         ],
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "nodenext",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "outDir": "../dist",


### PR DESCRIPTION
`node` is [quite outdated](https://www.typescriptlang.org/tsconfig#moduleResolution) and no longer recommended for use.

This bumps to nodenext which also allows us to enforce the `exports` entries in @osdk/* package.json files.